### PR TITLE
chore: upgrade HyperIndex to envio@3.2.1

### DIFF
--- a/.claude/skills/envio-docs/SKILL.md
+++ b/.claude/skills/envio-docs/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: envio-docs
+description: >-
+  Use when something is unclear, confusing, or not covered by other skills.
+  Search and read the latest Envio documentation without leaving the terminal.
+metadata:
+  managed-by: envio
+---
+
+- `envio tools search-docs "<query>"` — find docs pages by keyword
+- `envio tools fetch-docs <url>` — read a page in full (use a URL from search results)
+- `envio --help` — list available CLI commands and flags
+
+Example: `envio tools search-docs "schema derivedFrom"` → pick a URL → `envio tools fetch-docs <url>`

--- a/.claude/skills/indexer-blocks/SKILL.md
+++ b/.claude/skills/indexer-blocks/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: indexer-blocks
+description: >-
+  Use when processing every block (or every Nth block) for time-series data,
+  periodic snapshots, or block-level aggregations. indexer.onBlock API, where
+  filter with block-number range and stride, and block handler context.
+metadata:
+  managed-by: envio
+---
+
+# Block Handlers
+
+Process every block (or every Nth block) using `indexer.onBlock`. No contract
+address or `config.yaml` entry needed.
+
+## Handler
+
+Branch by `chain.id` with a `switch` so the type system flags any
+unconfigured chain via the `default: never` exhaustiveness check:
+
+```ts
+import { indexer } from "envio";
+
+indexer.onBlock(
+  {
+    name: "BlockTracker",
+    where: ({ chain }) => {
+      switch (chain.id) {
+        case 1:
+          return { block: { number: { _gte: 18000000, _every: 100 } } };
+        case 8453:
+          return { block: { number: { _every: 50 } } };
+        default: {
+          // Exhaustiveness check: TypeScript errors here if a new chain ID
+          // is added to config.yaml but not handled above.
+          const _exhaustive: never = chain.id;
+          return false;
+        }
+      }
+    },
+  },
+  async ({ block, context }) => {
+    context.BlockSnapshot.set({
+      id: `${block.number}`,
+      blockNumber: BigInt(block.number),
+    });
+  }
+);
+```
+
+## Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `name` | `string` | yes | Handler name for logging |
+| `where` | `({ chain }) => boolean \| filter` | no | Predicate evaluated once per configured chain at registration. Return `false` to skip a chain, `true` / omit to match every block, or `{block: {number: {_gte?, _lte?, _every?}}}` to restrict range and stride. `_every` aligns relative to `_gte`, preserving `(blockNumber - _gte) % _every === 0`. |
+
+## Other ecosystems
+
+- **Fuel**: same `indexer.onBlock` API; filter is keyed by `block.height` instead of `block.number`.
+- **SVM**: use `indexer.onSlot`; filter shape is `{slot: {_gte?, _lte?, _every?}}` and the handler arg is `{slot: number, context}` (no `block` wrapper).
+
+## Notes
+
+- `indexer.onBlock` self-registers — no `config.yaml` entry needed
+- No events or contract address required
+- The handler context has the same entity API as event handlers
+- If `where` returns `false` for every configured chain, a warning is logged at registration time
+- For per-event startBlock (not stride), use `indexer.onEvent` with `where.block.number._gte` (see `indexer-filters`). Event filters accept `_gte` only; `_lte`/`_every` are reserved for `onBlock`.
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-configuration/SKILL.md
+++ b/.claude/skills/indexer-configuration/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: indexer-configuration
+description: >-
+  Use when writing or editing config.yaml. Chain/contract structure, addresses,
+  start_block, event selection, field_selection, custom event names, env vars,
+  address_format, schema/output paths, YAML validation, and deprecated options.
+metadata:
+  managed-by: envio
+---
+
+# Config Reference (config.yaml)
+
+## Structure Overview
+
+```yaml
+name: my-indexer
+description: Optional description
+schema: schema.graphql         # custom path (default: schema.graphql)
+address_format: checksum       # checksum (default) | lowercase
+
+contracts:
+  - name: MyContract
+    abi_file_path: ./abis/MyContract.json
+    handler: ./src/EventHandlers.ts  # optional — auto-discovered from src/handlers/
+    events:
+      - event: Transfer(address indexed from, address indexed to, uint256 value)
+
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: MyContract
+        address: "0x1234..."
+```
+
+Uses `chains` (not `networks`) and `max_reorg_depth` (not `confirmed_block_threshold`).
+
+## Contract Addresses
+
+```yaml
+# Single address
+- name: Token
+  address: "0x1234..."
+
+# Multiple addresses
+- name: Token
+  address:
+    - "0xaaa..."
+    - "0xbbb..."
+
+# No address — wildcard indexing (all contracts matching ABI)
+- name: Token
+  # address omitted — indexes all matching events chain-wide
+
+# Factory-registered — see indexer-factory skill
+```
+
+For proxied contracts, use the **proxy address** (where events emit), not the implementation.
+
+## start_block
+
+```yaml
+chains:
+  - id: 1
+    start_block: 0            # 0 = HyperSync auto-detects first event block
+    contracts:
+      - name: Token
+        address: "0x1234..."
+        start_block: 18000000  # per-contract override (takes precedence)
+```
+
+`start_block: 0` with HyperSync skips empty blocks automatically.
+
+## Custom Event Names
+
+When two events share the same name (different signatures), disambiguate:
+
+```yaml
+events:
+  - event: Transfer(address indexed from, address indexed to, uint256 value)
+    name: TransferERC20
+  - event: Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
+    name: TransferERC721
+```
+
+## field_selection
+
+Request additional transaction/block fields globally or per event:
+
+```yaml
+# Global (root level — applies to all events)
+field_selection:
+  transaction_fields:
+    - hash
+    - from
+    - to
+  block_fields:
+    - number
+    - timestamp
+
+contracts:
+  - name: MyContract
+    events:
+      # Per-event (overrides global for this event)
+      - event: Transfer(address indexed from, address indexed to, uint256 value)
+        field_selection:
+          transaction_fields:
+            - hash
+            - from
+            - to
+            - gasPrice
+```
+
+Global `field_selection` is at the root level (sibling to `contracts` and `chains`). Per-event `field_selection` is directly under the event entry. See `indexer-transactions` skill for full field lists.
+
+## Environment Variables
+
+```yaml
+rpc:
+  - url: ${ENVIO_RPC_URL}                    # required — errors if missing
+  - url: ${ENVIO_RPC_URL:-http://localhost:8545}  # with default value
+```
+
+Works in any string value in config. Set via `.env` file or shell environment.
+
+**IMPORTANT:** All environment variables MUST use the `ENVIO_` prefix (e.g., `ENVIO_RPC_URL`, not `RPC_URL`). The hosted service requires the `ENVIO_` prefix — variables without it will not be available at runtime.
+
+## Runtime Environment Variables
+
+Set on the indexer process (not interpolated into config.yaml):
+
+- `ENVIO_TUI` — `true` forces the terminal UI on, `false` forces it off. Unset (default) auto-disables under agents, CI, and non-TTY stdout, so plain `pnpm dev` produces line-buffered output suitable for log capture without manual intervention.
+
+## YAML Validation
+
+Add at top of file for IDE schema validation:
+
+```yaml
+# yaml-language-server: $schema=./node_modules/envio/evm.schema.json
+```
+
+## Deprecated Options (Do NOT Use)
+
+- `loaders` / `preload_handlers` — replaced by async handler API
+- `preRegisterDynamicContracts` — replaced by `contractRegistrations` in factory pattern
+- `event_decoder` — removed
+- `rpc_config` — replaced by `rpc:` under chains
+- `unordered_multichain_mode` — removed
+
+## RPC Configuration
+
+RPC tuning parameters are documented in the `indexer-performance` skill.
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-external-calls/SKILL.md
+++ b/.claude/skills/indexer-external-calls/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: indexer-external-calls
+description: >-
+  Use when making RPC calls, fetch requests, or any external I/O from handlers.
+  Effect API with createEffect, S schema validation, context.effect(), preload
+  optimization (handlers run twice), cache and rateLimit options.
+metadata:
+  managed-by: envio
+---
+
+# External Calls (Effect API)
+
+Handlers run twice: parallel **preload pass** (warms caches), then **sequential pass** (state changes). All external I/O (fetch, RPC, APIs) MUST go through `createEffect` + `context.effect()` — otherwise it double-executes and blocks parallelization.
+
+## Define and call
+
+```ts
+import { S, createEffect } from "envio";
+
+const getOwner = createEffect(
+  {
+    name: "getOwner",
+    input: { tokenId: S.bigint },
+    output: S.union([S.string, null]),
+    cache: true,
+    rateLimit: false,
+  },
+  async ({ input }) => {
+    const res = await fetch(`https://api.example.com/owner/${input.tokenId}`);
+    return res.json();
+  }
+);
+
+indexer.onEvent(
+  { contract: "Token", event: "Transfer" },
+  async ({ event, context }) => {
+    const owner = await context.effect(getOwner, { tokenId: event.params.tokenId });
+  }
+);
+```
+
+## Pass minimum input
+
+`input` carries only what varies per call. Bake static config (URLs, tokens, channel IDs, env vars) into the effect body. Build payloads/strings inside the effect.
+
+```ts
+// ❌ input: { url, chatId, text }   — config and pre-built strings leak into the call site
+// ✅ input: { usd, blockNumber }    — only the values that vary per call
+```
+
+Dedup is keyed by hash of `input`; leaner inputs dedupe better, validate faster, and let one effect serve many call sites.
+
+## Schema (`S`)
+
+`S.string`, `S.number`, `S.bigint`, `S.boolean`, `S.schema({ ... })`, `S.array(...)`, `S.union([..., null])`, `S.optional(...)`.
+Full ref: https://raw.githubusercontent.com/DZakh/sury/refs/tags/v9.3.0/docs/js-usage.md
+
+## RPC pattern (viem)
+
+```ts
+const client = createPublicClient({ transport: http(process.env.ENVIO_RPC_URL) });
+
+const getTokenMetadata = createEffect(
+  {
+    name: "getTokenMetadata",
+    input: S.string,
+    output: { name: S.string, symbol: S.string, decimals: S.number },
+    cache: true,
+    rateLimit: false,
+  },
+  async ({ input: address }) => {
+    const args = { address: address as `0x${string}`, abi: ERC20_ABI };
+    const [name, symbol, decimals] = await Promise.all([
+      client.readContract({ ...args, functionName: "name" }),
+      client.readContract({ ...args, functionName: "symbol" }),
+      client.readContract({ ...args, functionName: "decimals" }),
+    ]);
+    return { name, symbol, decimals: Number(decimals) };
+  }
+);
+```
+
+## Options
+
+| Option | Type | Default |
+|---|---|---|
+| `name` | `string` | — |
+| `input` | `S.Schema` | — |
+| `output` | `S.Schema` | — |
+| `cache` | `boolean` | `false` |
+| `rateLimit` | `false \| { calls, per }` | required |
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-factory/SKILL.md
+++ b/.claude/skills/indexer-factory/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: indexer-factory
+description: >-
+  Use when indexing contracts deployed by factory contracts at runtime.
+  contractRegister API, dynamic contract config (no address), async
+  registration, and same-block event coverage.
+metadata:
+  managed-by: envio
+---
+
+# Factory / Dynamic Contracts
+
+For contracts created at runtime by factory contracts (e.g., Uniswap Pair creation).
+
+## Config
+
+Dynamic contracts have no address — they're registered by `contractRegister`:
+
+```yaml
+contracts:
+  - name: Factory
+    events:
+      - event: PairCreated(indexed address token0, indexed address token1, address pair, uint256)
+  - name: Pair
+    # No address — registered dynamically
+    events:
+      - event: Swap(indexed address sender, uint256 amount0In, ...)
+      - event: Sync(uint112 reserve0, uint112 reserve1)
+
+chains:
+  - id: 1
+    contracts:
+      - name: Factory
+        address:
+          - 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f
+      - name: Pair
+        # No address here — will be registered by contractRegister
+```
+
+## contractRegister
+
+Must be defined BEFORE the handler. Registers new contract addresses for indexing:
+
+```ts
+Factory.PairCreated.contractRegister(({ event, context }) => {
+  context.addPair(event.params.pair);
+});
+
+Factory.PairCreated.handler(async ({ event, context }) => {
+  const pair: Pair = {
+    id: `${event.chainId}-${event.params.pair}`,
+    token0_id: `${event.chainId}-${event.params.token0}`,
+    token1_id: `${event.chainId}-${event.params.token1}`,
+  };
+  context.Pair.set(pair);
+});
+```
+
+The `context.add<ContractName>()` methods are auto-generated based on contracts in config that have no address.
+
+## Async Contract Register
+
+Perform external calls to decide which contract to register:
+
+```ts
+NftFactory.SimpleNftCreated.contractRegister(async ({ event, context }) => {
+  const version = await getContractVersion(event.params.contractAddress);
+  if (version === "v2") {
+    context.addSimpleNftV2(event.params.contractAddress);
+  } else {
+    context.addSimpleNft(event.params.contractAddress);
+  }
+});
+```
+
+## Same-Block Coverage
+
+When a dynamic contract is registered, the Envio Indexer indexes all events from that contract in the **same block** where it was created — even events from earlier transactions in that block.
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-filters/SKILL.md
+++ b/.claude/skills/indexer-filters/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: indexer-filters
+description: >-
+  Use when filtering events by indexed parameters to reduce processing volume.
+  The `where` option supports static filters, dynamic per-chain functions,
+  contract address filtering, and conditional enable/disable.
+metadata:
+  managed-by: envio
+---
+
+# Event Filters (`where`)
+
+The `where` handler option filters events by indexed parameters and restricts the per-event block range. Works with or without `wildcard: true`.
+
+The filter value is a `{ params?, block? }` record. `params` can be a **single object** (AND-conjunction across indexed parameters) or an **array** of objects (OR across multiple AND-conjunctions). `block.number._gte` (or `block.height._gte` on Fuel) promotes to the event's **startBlock** and overrides the contract-level `start_block` from `config.yaml`.
+
+## Single Object Form
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: { params: { from: ZERO_ADDRESS, to: WHITELISTED } },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+## Array Form — Static Filters (OR)
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: {
+      params: [{ from: ZERO_ADDRESS }, { to: ZERO_ADDRESS }],
+    },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+Each entry in the `params` array is **OR'd** together. Within a single entry, fields are **AND'd**. Arrays in a field position match **any** value in the array.
+
+## Function Form — Dynamic Per-Chain
+
+Return a filter based on the current `chain`. The callback receives `{ chain }` where `chain.id` is the chain ID and `chain.<ContractName>.addresses` exposes the indexed addresses of the event's own contract on that chain. Return `false` to skip the chain entirely (no events processed), or `true` to allow all events. To filter, return a `{params: ...}` object where `params` is a single record or an array of records:
+
+```ts
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const WHITELISTED = {
+  137: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" as const],
+  100: ["0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC" as const],
+};
+
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: ({ chain }) => {
+      if (chain.id !== 100 && chain.id !== 137) return false;
+      return {
+        params: [
+          { from: ZERO_ADDRESS, to: WHITELISTED[chain.id] },
+          { from: WHITELISTED[chain.id], to: ZERO_ADDRESS },
+        ],
+      };
+    },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+## Function with `chain.<Contract>.addresses` — Filter by Registered Contracts
+
+For dynamically registered contracts, use `chain.<ContractName>.addresses` to filter by their addresses. Only the event's own contract is exposed:
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: ({ chain }) => {
+      if (chain.id !== 100 && chain.id !== 137) return false;
+      return {
+        params: [
+          { from: ZERO_ADDRESS, to: chain.ERC20.addresses },
+          { from: chain.ERC20.addresses, to: ZERO_ADDRESS },
+        ],
+      };
+    },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+## Per-Event `startBlock` via `block.number._gte`
+
+Use `where.block` as a sibling of `params` to restrict an event to blocks at or after a given number. Overrides the contract's `start_block` from `config.yaml` — useful for narrowing a single event without touching the whole contract.
+
+Use a `switch` on `chain.id` to pick the `startBlock` only, so the shared `params` filter isn't duplicated per chain. The `default: never` branch makes TypeScript flag any chain added to `config.yaml` but not handled here:
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: ({ chain }) => {
+      let startBlock: number;
+      switch (chain.id) {
+        case 1:
+          startBlock = 18000000;
+          break;
+        case 8453:
+          startBlock = 2000000;
+          break;
+        default: {
+          // Exhaustiveness check: TypeScript errors here if a new chain ID
+          // is added to config.yaml but not handled above.
+          const _exhaustive: never = chain.id;
+          return false;
+        }
+      }
+      return {
+        block: { number: { _gte: startBlock } },
+        params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
+      };
+    },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+On Fuel, key the block range on `block.height` instead of `block.number`. SVM has no event handlers. Only `_gte` is accepted on event filters. The `block` filter is only valid at the top level of `where`, not nested inside `params` array entries.
+
+## Filter Semantics
+
+- Filter fields inside each `params` entry correspond to the event's **indexed parameters** only
+- Multiple entries in the `params` array → OR (match any)
+- Multiple fields in one entry → AND (match all)
+- Array value in a field → match any value in the array
+- `block.number._gte` (EVM) / `block.height._gte` (Fuel) → per-event startBlock, overrides contract `start_block`
+- `return false` → skip the chain entirely (no events processed for that chain)
+- `return true` → accept all events (no filtering, default topic0-only selection)
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-handlers/SKILL.md
+++ b/.claude/skills/indexer-handlers/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: indexer-handlers
+description: >-
+  Use when writing or editing event handlers. Handler registration, context API
+  (entity CRUD, getWhere queries, chain, log), spread updates, indexer runtime
+  API, and common pitfalls.
+metadata:
+  managed-by: envio
+---
+
+# Handler Syntax & Core API
+
+## ESM Project
+
+This is an ESM project (`"type": "module"` in package.json). Top-level `await` is available. Use `import`/`export` syntax, not `require`.
+
+## Modification Workflow
+
+1. After any change to `schema.graphql` or `config.yaml` → run `pnpm codegen`
+2. After any change to TypeScript files → run `pnpm tsc --noEmit`
+3. Once compilation succeeds → run `pnpm dev` to catch runtime errors
+
+## Handler Registration
+
+```ts
+import { Contract } from "envio";
+
+Contract.Event.handler(async ({ event, context }) => {
+  // event.params.<name>  — decoded event parameters
+  // event.chainId        — chain ID
+  // event.srcAddress     — emitting contract address (checksummed)
+  // event.logIndex       — log index within block
+  // event.block          — { number, timestamp, hash }
+  // event.transaction    — transaction fields (configure via field_selection)
+});
+```
+
+Handlers accept an optional 2nd argument — see `indexer-wildcard` and `indexer-filters` skills.
+
+## Context API
+
+### Entity Operations
+
+```ts
+// Read
+const entity = await context.Entity.get(id);              // Entity | undefined
+const entity = await context.Entity.getOrThrow(id);       // throws if missing
+const entity = await context.Entity.getOrCreate({ id, ...defaults });
+
+// Query by indexed fields (@index in schema)
+const list = await context.Entity.getWhere({ fieldName: { _eq: value } });
+const list = await context.Entity.getWhere({ fieldName: { _gt: value } });
+const list = await context.Entity.getWhere({ fieldName: { _lt: value } });
+const list = await context.Entity.getWhere({ fieldName: { _gte: value } });
+const list = await context.Entity.getWhere({ fieldName: { _lte: value } });
+const list = await context.Entity.getWhere({ fieldName: { _in: [value1, value2] } });
+const list = await context.Entity.getWhere({ fieldName: { _gte: min, _lte: max } });
+const list = await context.Entity.getWhere({ fieldA: { _eq: a }, fieldB: { _eq: b } });
+
+// Write
+context.Entity.set(entity);          // create or update (sync — no await)
+context.Entity.deleteUnsafe(id);     // delete (sync — no await)
+```
+
+`getWhere` operators: `_eq`, `_gt`, `_lt`, `_gte`, `_lte`, `_in`. Multiple fields and operators combine with AND semantics. Only `id` and `@index` fields are queryable. See `indexer-schema` for @index syntax.
+
+### Context Properties
+
+```ts
+context.chain.id           // number — current chain ID
+context.chain.isRealtime   // boolean — true when ALL chains have caught up to head
+context.isPreload      // boolean — true during preload phase
+context.log            // { debug, info, warn, error, errorWithExn }
+context.effect(fn, input)  // external call via Effect API (see indexer-external-calls)
+```
+
+## Spread Operator for Updates
+
+Entities from `context.Entity.get()` are **read-only**. Always spread:
+
+```ts
+const entity = await context.Entity.get(id);
+if (entity) {
+  context.Entity.set({ ...entity, field: newValue });
+}
+```
+
+## `indexer` Runtime API
+
+```ts
+import { indexer } from "envio";
+
+indexer.name;                        // "my-indexer"
+indexer.chainIds;                    // [1, 137]
+indexer.chains[1].id;                // 1
+indexer.chains[1].name;              // "ethereum"
+indexer.chains[1].startBlock;        // 0
+indexer.chains[1].isRealtime;        // false
+indexer.chains[1].MyContract.name;   // "MyContract"
+indexer.chains[1].MyContract.addresses; // ["0x..."]
+indexer.chains[1].MyContract.abi;    // [...]
+```
+
+## Common Pitfalls
+
+**Entity IDs** — prefer `${chainId}_${blockNumber}_${logIndex}` as a unique ID:
+```ts
+const id = `${event.chainId}_${event.block.number}_${event.logIndex}`;
+```
+This is globally unique across chains and blocks. Use it as the default unless the entity is a singleton (e.g., a Token or Pool keyed by address).
+
+**Entity relationships** — schema uses entity references; handlers use the `_id` suffix that codegen adds:
+```ts
+// Schema:   token0: Token!       ← entity reference, field name is "token0"
+// Handler:  { token0_id: token0.id }  ← codegen adds _id; NEVER write "token0" here
+
+// Schema:   collection: NftCollection!
+// Handler:  { collection_id: collectionEntity.id }
+
+// WRONG:  { token0: token0.id }  ← "token0" is not a valid TypeScript field
+// WRONG:  { collection_id: String! } in schema  ← _id belongs in handlers, not schema
+// CORRECT: { token0_id: token0.id }  in handler
+```
+
+**Optionals** — `string | undefined`, not `string | null`
+
+**Decimal normalization** — ALWAYS normalize when adding tokens with different decimals.
+
+**Schema & config** — see `indexer-schema` and `indexer-configuration` skills for full reference.
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-multichain/SKILL.md
+++ b/.claude/skills/indexer-multichain/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: indexer-multichain
+description: >-
+  Use when deploying an indexer across multiple chains. Entity ID namespacing
+  to avoid collisions, chain-specific configuration patterns, and the
+  context.chain runtime API.
+metadata:
+  managed-by: envio
+---
+
+# Multichain Indexing
+
+## Entity ID Namespacing
+
+Always prefix entity IDs with `chainId` to avoid collisions across chains:
+
+```ts
+const id = `${event.chainId}-${event.params.tokenId}`;
+context.Token.set({ id, ...tokenData });
+```
+
+Never hardcode `chainId = 1` — always use `event.chainId`.
+
+Chain-specific singleton IDs (e.g., Bundle): `${event.chainId}-1`
+
+## Chain-Specific Logic
+
+```ts
+Contract.Event.handler(async ({ event, context }) => {
+  const chainId = context.chain.id;
+
+  const config = {
+    1: { wrappedNative: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+    137: { wrappedNative: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270" },
+  }[chainId];
+
+  // context.chain.isRealtime is true once ALL chains have caught up to head
+  if (context.chain.isRealtime) {
+    // Realtime-only logic
+  }
+});
+```
+
+## Config
+
+Global contract definitions + chain-specific addresses:
+
+```yaml
+contracts:
+  - name: ERC20
+    events:
+      - event: Transfer(indexed address from, indexed address to, uint256 value)
+
+chains:
+  - id: 1
+    contracts:
+      - name: ERC20
+        address:
+          - 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+  - id: 137
+    contracts:
+      - name: ERC20
+        address:
+          - 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174
+```
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-performance/SKILL.md
+++ b/.claude/skills/indexer-performance/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: indexer-performance
+description: >-
+  Use when optimizing indexer speed or tuning sync performance. HyperSync vs
+  RPC, batch size, RPC tuning parameters, WebSocket config, and preload
+  optimization.
+metadata:
+  managed-by: envio
+---
+
+# Performance Tuning
+
+## HyperSync (Default — Fastest)
+
+HyperSync is the default data source for supported chains. Up to 1000x faster than RPC. No configuration needed — automatic for supported networks.
+
+## Batch Size
+
+```yaml
+full_batch_size: 5000  # Target events per batch (default: 5000)
+```
+
+Reduce if handlers make many slow Effect API calls that can't be batched.
+
+## RPC Tuning
+
+When using RPC as a data source, tune these parameters per chain:
+
+```yaml
+chains:
+  - id: 1
+    rpc:
+      - url: ${ENVIO_RPC_URL}
+        for: sync                    # sync | realtime | fallback
+        ws: ${ENVIO_WS_URL}               # WebSocket for lower-latency realtime block detection
+        initial_block_interval: 5000 # Starting blocks per query
+        backoff_multiplicative: 0.8  # Scale factor after RPC error (0.5-0.9)
+        acceleration_additive: 1000  # Blocks added per successful query
+        interval_ceiling: 10000      # Max blocks per query
+        backoff_millis: 5000         # Wait after error before retry (ms)
+        query_timeout_millis: 20000  # Cancel RPC request after this (ms)
+        fallback_stall_timeout: 5000 # Switch to next RPC after stall (ms)
+        polling_interval: 1000       # Check for new blocks every N ms (default: 1000)
+```
+
+### RPC `for` Options
+
+| Value | Description |
+|-------|-------------|
+| `sync` | RPC as main data source for both historical and realtime |
+| `realtime` | HyperSync for historical, switch to RPC for realtime (lower latency) |
+| `fallback` | Backup when primary stalls (default when HyperSync available) |
+
+### WebSocket for Realtime Indexing
+
+Add `ws:` for lower-latency new block detection via `eth_subscribe("newHeads")`:
+
+```yaml
+rpc:
+  - url: ${ENVIO_RPC_ENDPOINT}
+    ws: ${ENVIO_WS_ENDPOINT}
+    for: realtime
+```
+
+## Database Indexes
+
+Add `@index` to schema fields for faster queries — see `indexer-schema` for full syntax (single-field, composite, DESC direction).
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-schema/SKILL.md
+++ b/.claude/skills/indexer-schema/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: indexer-schema
+description: >-
+  Use when defining or editing schema.graphql. Entity types, scalar types,
+  enums, relationships, @derivedFrom, @index, @config directives, array rules,
+  naming conventions, and schema-to-TypeScript type mapping.
+metadata:
+  managed-by: envio
+---
+
+# Schema Reference (schema.graphql)
+
+## Entity Rules
+
+- Every type is an entity — **no `@entity` decorator** (unlike TheGraph)
+- Must have `id: ID!` as first field
+- Names: 1-63 chars, alphanumeric + underscore, no reserved words
+- Relationship fields use the **entity type directly**: `collection: NftCollection!` — **never** add `_id` in the schema field name
+- The `_id` suffix only appears in TypeScript handlers (added by codegen): schema field `collection` → handler field `collection_id`
+
+## Scalar Types
+
+| Schema Type | TypeScript Type | Notes |
+|-------------|----------------|-------|
+| `ID!` | `string` | Required on every entity |
+| `String!` | `string` | |
+| `Int!` | `number` | |
+| `Float!` | `number` | |
+| `Boolean!` | `boolean` | |
+| `BigInt!` | `bigint` | Use `@config(precision: N)` for custom precision |
+| `BigDecimal!` | `BigDecimal` | Use `@config(precision: N, scale: M)` |
+| `Bytes!` | `string` | Hex-encoded |
+| `Timestamp!` | `Date` | |
+| `Json!` | `any` | |
+
+## Enums
+
+```graphql
+enum Status {
+  Active
+  Inactive
+  Paused
+}
+
+type Pool {
+  id: ID!
+  status: Status!
+  allowedStatuses: [Status!]!  # enum arrays supported
+}
+```
+
+## @derivedFrom
+
+Virtual reverse-lookup — **cannot access in handlers**, only in API queries:
+
+```graphql
+type Pool {
+  id: ID!
+  swaps: [Swap!]! @derivedFrom(field: "pool")
+}
+
+type Swap {
+  id: ID!
+  pool: Pool!  # entity reference — field name matches @derivedFrom "field" arg
+}
+```
+
+**Critical rules:**
+- The `field` argument must match the **schema field name** on the child entity — which is the entity reference name (`"pool"`), **not** `"pool_id"`
+- In TypeScript handlers, set this relationship using the `_id` suffix: `pool_id: poolEntity.id` — codegen transforms `pool: Pool!` → `pool_id` in the TypeScript type
+- **Never write `pool_id: String!` in the schema when using `@derivedFrom(field: "pool")`.** The schema field must be `pool: Pool!`; the `_id` is a codegen artifact for handlers only
+
+## @index
+
+Single-field index for faster queries:
+
+```graphql
+type Transfer {
+  id: ID!
+  from: String! @index
+  to: String! @index
+  timestamp: BigInt! @index
+}
+```
+
+Composite index with optional DESC direction:
+
+```graphql
+type Trade @index(fields: ["poolId", ["date", "DESC"]]) {
+  id: ID!
+  poolId: String!
+  date: BigInt!
+  volume: BigDecimal!
+}
+```
+
+- Fields default to ASC; use `["field", "DESC"]` for descending
+- IDs and `@derivedFrom` fields are automatically indexed
+- Only `id` and `@index` fields are queryable via `context.Entity.getWhere()`
+
+## @config
+
+Customize precision for numeric types:
+
+```graphql
+type Token {
+  id: ID!
+  totalSupply: BigInt! @config(precision: 100)
+  price: BigDecimal! @config(precision: 30, scale: 15)
+}
+```
+
+- `BigInt` default precision: 76 digits
+- `BigDecimal` default: precision 76, scale 32
+
+## Array Rules
+
+- Supported: `[Type!]!` — non-nullable elements, non-nullable array
+- **Not supported**: `[Type]!` (nullable elements), nested arrays, `[Boolean!]!`, `[Timestamp!]!`
+- Entity arrays require `@derivedFrom` — bare `[Swap!]!` without it causes a codegen error
+
+## Example
+
+```graphql
+enum PoolType {
+  UniswapV2
+  UniswapV3
+}
+
+type Token {
+  id: ID!
+  symbol: String!
+}
+
+type Pool @index(fields: ["token0", "token1"]) {
+  id: ID!
+  poolType: PoolType!
+  token0: Token!   # entity reference — handler uses token0_id
+  token1: Token!   # entity reference — handler uses token1_id
+  reserve0: BigInt!
+  reserve1: BigInt!
+  totalValueLocked: BigDecimal! @config(precision: 30, scale: 15)
+  swaps: [Swap!]! @derivedFrom(field: "pool")  # "pool" matches Swap.pool field name
+}
+
+type Swap {
+  id: ID!
+  pool: Pool! @index   # entity reference — handler uses pool_id; @derivedFrom field arg = "pool"
+  sender: String! @index
+  amount0In: BigInt!
+  amount1In: BigInt!
+  timestamp: BigInt! @index
+}
+```
+
+**Schema vs handler field names:**
+
+| Schema field | Schema type | TypeScript handler field |
+|---|---|---|
+| `pool` | `Pool!` | `pool_id: string` |
+| `token0` | `Token!` | `token0_id: string` |
+| `collection` | `NftCollection!` | `collection_id: string` |
+
+Codegen always appends `_id` to entity reference field names in the TypeScript types. Do **not** add `_id` yourself in the schema.
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-testing/SKILL.md
+++ b/.claude/skills/indexer-testing/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: indexer-testing
+description: >-
+  Write and run tests for Envio Indexer projects using Vitest and createTestIndexer().
+  Covers test setup, processing block ranges, asserting entity changes with
+  toMatchInlineSnapshot, and TDD workflow. Use when writing tests, debugging
+  handler output, or verifying indexer behavior.
+metadata:
+  managed-by: envio
+---
+
+# Envio Indexer Testing
+
+## Setup
+
+The Envio Indexer uses Vitest with `createTestIndexer()` from `envio`. The simplest way to start is auto-exit mode — no block ranges needed. The indexer automatically finds the first block with events and processes it.
+
+```ts
+import { describe, it } from "vitest";
+import { createTestIndexer } from "envio";
+
+describe("Indexer Testing", () => {
+  it("Should process first two blocks with events", async (t) => {
+    const indexer = createTestIndexer();
+
+    t.expect(
+      await indexer.process({ chains: { 1: {} } }),
+      "Should find the first block with an event on chain 1 and process it."
+    ).toMatchInlineSnapshot(``);
+
+    t.expect(
+      await indexer.process({ chains: { 1: {} } }),
+      "Should find the second block with an event on chain 1 and process it."
+    ).toMatchInlineSnapshot(``);
+  });
+});
+```
+
+Run `pnpm test` — Vitest auto-fills the snapshots on first run. Review and commit.
+
+## Process API
+
+### Auto-exit (recommended for getting started)
+
+Processes the first block with matching events, then exits. Each subsequent call continues from where the previous one stopped.
+
+```ts
+const result = await indexer.process({
+  chains: {
+    1: {},           // auto-detect first block with events on chain 1
+    8453: {},        // same for chain 8453
+  },
+});
+```
+
+### Explicit block range
+
+Process a specific block range. Use when you need deterministic, pinned snapshots.
+
+```ts
+const result = await indexer.process({
+  chains: {
+    1: { startBlock: 10_000_000, endBlock: 10_000_100 },
+  },
+});
+```
+
+### Simulate (mock events)
+
+Feed synthetic events without hitting the network. Best for unit-testing handler logic.
+
+```ts
+await indexer.process({
+  chains: {
+    1: {
+      simulate: [
+        {
+          contract: "ERC20",
+          event: "Transfer",
+          params: { from: addr1, to: addr2, value: 100n },
+        },
+      ],
+    },
+  },
+});
+```
+
+## Entity State API
+
+Preset state before processing and read entities after.
+
+```ts
+// Preset state before processing
+indexer.EntityName.set({ id: "...", field: value });
+
+// Read state after processing
+await indexer.EntityName.get("id");        // returns entity | undefined
+await indexer.EntityName.getOrThrow("id"); // throws if not found
+await indexer.EntityName.getAll();         // returns all entities of this type
+```
+
+## result.changes
+
+`result.changes` is an array of per-block change objects. Each entry has `block`, `chainId`, `eventsProcessed`, plus entity names as keys with `sets` arrays of created/updated entities. Dynamic contract registrations appear under `addresses.sets`.
+
+## Assertions
+
+```ts
+// Snapshot (recommended — captures full output, auto-filled on first run)
+t.expect(result.changes).toMatchInlineSnapshot(`...`);
+
+// Entity assertions
+const pool = await indexer.Pool.getOrThrow(poolId);
+t.expect(pool).toEqual({ id: poolId, token0_id: "0xabc..." });
+
+// Count
+t.expect(result.changes[0]?.Pair?.sets).toHaveLength(1);
+
+// Contract addresses (after dynamic registration)
+t.expect(indexer.chains[1].MyContract.addresses).toContain("0x1234...");
+```
+
+## TDD Workflow
+
+1. **Write a failing test** with expected entity output
+2. **Implement the handler** until the test passes
+3. **Capture the snapshot** — run `pnpm test` to fill `toMatchInlineSnapshot`
+4. **Review and commit** the snapshot for regression testing
+
+## Running Tests
+
+```bash
+pnpm test              # Run all tests
+pnpm test -- -u        # Update snapshots
+```
+
+## Advanced: Finding Block Ranges with HyperSync
+
+Auto-exit mode eliminates the need for manual block discovery in most cases. Use this when you need specific block ranges for pinned snapshots.
+
+**Do NOT web-search for block ranges.** Query HyperSync directly. Endpoint pattern: `https://{chainId}.hypersync.xyz` (e.g., chain 1 → `https://1.hypersync.xyz`).
+
+Common chain IDs: 1 (Ethereum), 8453 (Base), 42161 (Arbitrum), 10 (Optimism), 137 (Polygon), 56 (BSC), 43114 (Avalanche), 100 (Gnosis), 59144 (Linea), 534352 (Scroll), 81457 (Blast), 42220 (Celo).
+
+```bash
+curl --request POST \
+  --url https://1.hypersync.xyz/query \
+  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $ENVIO_API_TOKEN" \
+  --data '{
+    "from_block": 0,
+    "logs": [
+      {
+        "address": ["0xYOUR_CONTRACT_ADDRESS"],
+        "topics": [
+          ["0xYOUR_EVENT_TOPIC0"]
+        ]
+      }
+    ],
+    "field_selection": {
+      "log": ["block_number"]
+    }
+  }'
+```
+
+Returns the earliest matching blocks. Use `from_block` to paginate forward. Pick a tight range (50–200 blocks) for fast, deterministic tests.
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-traces/SKILL.md
+++ b/.claude/skills/indexer-traces/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: indexer-traces
+description: >-
+  Use when needing call trace data from transactions. HyperSync supports trace
+  queries at the data layer. No handler-level trace API currently — access
+  traces via HyperSync client directly.
+metadata:
+  managed-by: envio
+---
+
+# Trace Indexing
+
+## Current Status
+
+HyperSync supports full trace queries at the data layer, but the Envio Indexer does not yet expose a handler-level trace API (like `onTrace`).
+
+## HyperSync Trace Support
+
+HyperSync can query traces with filtering by:
+- `from` / `to` — sender/recipient addresses
+- `address` — contract address
+- `callType` — call, delegatecall, staticcall
+- `type` — call, create, suicide, reward
+- `sighash` — function signatures
+
+Available trace fields: `From`, `To`, `CallType`, `Gas`, `Input`, `Value`, `GasUsed`, `Output`, `Subtraces`, `TraceAddress`, `TransactionHash`, `BlockNumber`, `Error`, and more.
+
+## Workaround
+
+For trace-dependent indexing, use the Effect API to fetch trace data from an RPC endpoint:
+
+```ts
+import { createEffect, S } from "envio";
+
+const getTraces = createEffect(
+  {
+    name: "getTraces",
+    input: S.schema({ blockNumber: S.number }),
+    output: S.unknown,
+    cache: true,
+  },
+  async ({ input }) => {
+    const res = await fetch(RPC_URL, {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "trace_block",
+        params: [`0x${input.blockNumber.toString(16)}`],
+        id: 1,
+      }),
+    });
+    return (await res.json()).result;
+  }
+);
+```
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-transactions/SKILL.md
+++ b/.claude/skills/indexer-transactions/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: indexer-transactions
+description: >-
+  Use when needing transaction-level data in handlers. Configure field_selection
+  to include transaction fields on events, and access via event.transaction.
+  No native transaction handler — access through event handlers.
+metadata:
+  managed-by: envio
+---
+
+# Transaction Data
+
+The Envio Indexer does not have a native transaction handler (`onTransaction`). Transaction data is accessed through event handlers via `field_selection` in config.yaml.
+
+## Configuring Transaction Fields
+
+By default, `event.transaction` is empty. Select needed fields explicitly:
+
+```yaml
+contracts:
+  - name: MyContract
+    events:
+      - event: Transfer(indexed address from, indexed address to, uint256 value)
+        field_selection:
+          transaction_fields:
+            - hash
+            - from
+            - to
+            - gasUsed
+            - value
+```
+
+Or globally for all events:
+
+```yaml
+field_selection:
+  transaction_fields:
+    - hash
+    - from
+    - to
+```
+
+## Accessing in Handlers
+
+```ts
+Contract.Transfer.handler(async ({ event, context }) => {
+  const txHash = event.transaction.hash;
+  const txFrom = event.transaction.from;
+  const gasUsed = event.transaction.gasUsed;
+});
+```
+
+## Available Transaction Fields
+
+`transactionIndex`, `hash`, `from`, `to`, `gas`, `gasPrice`, `maxPriorityFeePerGas`, `maxFeePerGas`, `cumulativeGasUsed`, `effectiveGasPrice`, `gasUsed`, `input`, `nonce`, `value`, `v`, `r`, `s`, `contractAddress`, `logsBloom`, `root`, `status`, `yParity`, `chainId`, `maxFeePerBlobGas`, `blobVersionedHashes`, `type`, `l1Fee`, `l1GasPrice`, `l1GasUsed`, `l1FeeScalar`, `gasUsedForL1`
+
+## Available Block Fields
+
+Block fields are also configurable via `block_fields`. Default: `number`, `timestamp`, `hash`.
+
+Additional: `parentHash`, `nonce`, `sha3Uncles`, `logsBloom`, `transactionsRoot`, `stateRoot`, `receiptsRoot`, `miner`, `difficulty`, `totalDifficulty`, `extraData`, `size`, `gasLimit`, `gasUsed`, `uncles`, `baseFeePerGas`, `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`, `withdrawalsRoot`, `l1BlockNumber`
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.claude/skills/indexer-troubleshooting/SKILL.md
+++ b/.claude/skills/indexer-troubleshooting/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: indexer-troubleshooting
+description: >-
+  Use when the indexer fails to start, codegen errors, types are stale,
+  Docker or database issues, RPC errors, or something is not working.
+  Common error messages and fixes.
+metadata:
+  managed-by: envio
+---
+
+# Troubleshooting
+
+## Stale Types / Codegen Issues
+
+**Symptom:** Type errors after editing `schema.graphql` or `config.yaml`.
+
+```bash
+pnpm codegen
+```
+
+Always run codegen after any schema or config change.
+
+## Docker / Database Not Running
+
+**Symptom:** `pnpm dev` fails with connection refused or database errors.
+
+```bash
+docker info  # check Docker is running
+```
+
+The indexer needs Docker for PostgreSQL. Start Docker and retry.
+
+## Environment Variables
+
+All env vars MUST use the `ENVIO_` prefix. The hosted service only exposes variables with this prefix at runtime.
+
+```yaml
+# WRONG
+rpc:
+  - url: ${RPC_URL}
+
+# CORRECT
+rpc:
+  - url: ${ENVIO_RPC_URL}
+```
+
+## RPC / HyperSync Errors
+
+**"rate limited" or timeout errors:** See `indexer-performance` skill for RPC tuning parameters.
+
+**Missing `ENVIO_API_TOKEN`:** Required for HyperSync. Get an Envio API token at https://envio.dev/app/api-tokens, then set it in `.env` or shell environment.
+
+## Common Runtime Errors
+
+**"field not indexed"** — `getWhere` only works on `id` and fields with `@index` in `schema.graphql`.
+
+**"entity is read-only"** — Entities from `context.Entity.get()` are frozen. Spread to update: `context.Entity.set({ ...entity, field: newValue })`.
+
+**"Cannot find module 'envio'"** — Run `pnpm install`.
+
+**Codegen output stale after `config.yaml` change** — Run `pnpm codegen` again.

--- a/.claude/skills/indexer-wildcard/SKILL.md
+++ b/.claude/skills/indexer-wildcard/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: indexer-wildcard
+description: >-
+  Use when indexing all instances of a contract across all addresses (e.g., all
+  ERC-20 transfers on a chain). Config setup (no address), wildcard handler
+  option, and event.srcAddress.
+metadata:
+  managed-by: envio
+---
+
+# Wildcard Indexing
+
+Index all events matching an event signature across all contract addresses on a chain.
+
+## Config (no address = wildcard)
+
+```yaml
+contracts:
+  - name: ERC20
+    events:
+      - event: Transfer(indexed address from, indexed address to, uint256 value)
+
+chains:
+  - id: 1
+    contracts:
+      - name: ERC20
+        # No address = wildcard (indexes ALL matching events on the chain)
+```
+
+## Handler with `wildcard: true`
+
+Pass `wildcard: true` in the options object to `indexer.onEvent`. Use `event.srcAddress` to identify which contract emitted the event:
+
+```ts
+indexer.onEvent(
+  { contract: "ERC20", event: "Transfer", wildcard: true },
+  async ({ event, context }) => {
+    const tokenAddress = event.srcAddress; // The actual contract address
+    const id = `${event.chainId}-${event.transaction.hash}-${event.logIndex}`;
+
+    context.Transfer.set({
+      id,
+      token_id: `${event.chainId}-${tokenAddress}`,
+      from: event.params.from,
+      to: event.params.to,
+      value: event.params.value,
+    });
+  },
+);
+```
+
+## Combining with Event Filters (`where`)
+
+Wildcard indexing produces high event volume. Use `where` to reduce it — see the `indexer-filters` skill for object, array, function, and `addresses` forms.
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: { params: { from: ZERO_ADDRESS } },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+> If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ logs
 *.gen.ts
 build
 .env
+.envio/

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=./node_modules/envio/evm.schema.json
 name: envio-graph2
-networks:
+chains:
   - id: 137
     start_block: ${ENVIO_START_BLOCK}
     contracts:
@@ -11,5 +11,3 @@ networks:
         events:
           - event: DataGroupHeartBeat(bytes32 indexed propertyHash, bytes32 indexed dataGroupHash, bytes32 indexed dataHash, address submitter)
           - event: DataSubmitted(bytes32 indexed propertyHash, bytes32 indexed dataGroupHash, address indexed submitter, bytes32 dataHash)
-unordered_multichain_mode: true
-preload_handlers: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,14 @@
 # yaml-language-server: $schema=./node_modules/envio/evm.schema.json
 name: envio-graph2
+contracts:
+  - name: ERC1967Proxy
+    handler: src/EventHandlers.ts
+    events:
+      - event: DataGroupHeartBeat(bytes32 indexed propertyHash, bytes32 indexed dataGroupHash, bytes32 indexed dataHash, address submitter)
+      - event: DataSubmitted(bytes32 indexed propertyHash, bytes32 indexed dataGroupHash, address indexed submitter, bytes32 dataHash)
 chains:
   - id: 137
     start_block: ${ENVIO_START_BLOCK}
     contracts:
       - name: ERC1967Proxy
-        address:
-          - ${ENVIO_CONTRACT_ADDRESS}
-        handler: src/EventHandlers.ts
-        events:
-          - event: DataGroupHeartBeat(bytes32 indexed propertyHash, bytes32 indexed dataGroupHash, bytes32 indexed dataHash, address submitter)
-          - event: DataSubmitted(bytes32 indexed propertyHash, bytes32 indexed dataGroupHash, address indexed submitter, bytes32 dataHash)
+        address: "${ENVIO_CONTRACT_ADDRESS}"

--- a/package.json
+++ b/package.json
@@ -21,13 +21,11 @@
     "mocha": "10.2.0"
   },
   "dependencies": {
-    "envio": "2.28.0"
-  },
-  "optionalDependencies": {
-    "generated": "./generated"
+    "envio": "3.2.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81",
+  "type": "module"
 }

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -1,16 +1,7 @@
 /*
  * Please refer to https://docs.envio.dev for a thorough guide on all Envio indexer features
  */
-import {
-  ERC1967Proxy,
-  ERC1967Proxy_DataGroupHeartBeat,
-  ERC1967Proxy_DataSubmitted,
-  DataSubmittedWithLabel,
-  Structure,
-  Address,
-  Property,
-  Ipfs,
-} from "generated";
+import { indexer, ERC1967Proxy, ERC1967Proxy_DataGroupHeartBeat, ERC1967Proxy_DataSubmitted, DataSubmittedWithLabel, Property } from "envio";
 
 import { bytes32ToCID, getIpfsMetadata, getPropertyData } from "./utils/ipfs";
 import { getAllowedSubmitters, processCountyData, processPropertyImprovementData } from "./utils/eventHelpers";
@@ -18,7 +9,9 @@ import { getAllowedSubmitters, processCountyData, processPropertyImprovementData
 // Get allowed submitters from environment variables - this will crash if none found
 const allowedSubmitters = getAllowedSubmitters();
 
-ERC1967Proxy.DataGroupHeartBeat.handler(async ({ event, context }) => {
+indexer.onEvent(
+  { contract: "ERC1967Proxy", event: "DataGroupHeartBeat" },
+  async ({ event, context }) => {
   if (!allowedSubmitters.includes(event.params.submitter)) {
     // Skipping HeartBeat event - only processing events from specific submitters
     return;
@@ -119,9 +112,12 @@ ERC1967Proxy.DataGroupHeartBeat.handler(async ({ event, context }) => {
       error: (error as Error).message
     });
   }
-});
+}
+);
 
-ERC1967Proxy.DataSubmitted.handler(async ({ event, context }) => {
+indexer.onEvent(
+  { contract: "ERC1967Proxy", event: "DataSubmitted" },
+  async ({ event, context }) => {
   if (!allowedSubmitters.includes(event.params.submitter)) {
     // Skipping DataSubmitted event - only processing events from specific submitters
     return;
@@ -360,4 +356,5 @@ ERC1967Proxy.DataSubmitted.handler(async ({ event, context }) => {
       error: (error as Error).message
     });
   }
-});
+}
+);

--- a/src/utils/eventHelpers.ts
+++ b/src/utils/eventHelpers.ts
@@ -1,22 +1,4 @@
-import {
-  DataSubmittedWithLabel,
-  Structure,
-  Address,
-  Property,
-  Ipfs,
-  Lot,
-  SalesHistory,
-  Tax,
-  Utility,
-  FloodStormInformation,
-  Person,
-  Company,
-  Layout,
-  File,
-  Deed,
-  PropertyImprovement,
-  Communication,
-} from "generated";
+import { Structure, Address, Property, Ipfs, Lot, SalesHistory, Tax, Utility, FloodStormInformation, Person, Company, Layout, File, Deed, PropertyImprovement, Communication } from "envio";
 import { bytes32ToCID, getIpfsMetadata, getRelationshipData, getStructureData, getAddressData, getPropertyData, getIpfsFactSheetData, getLotData, getSalesHistoryData, getTaxData, getUtilityData, getFloodStormData, getPersonData, getCompanyData, getDeedData,getFileData,getLayoutData, getPropertyImprovementData, getCommunicationData } from "./ipfs";
 
 // Function to get all wallet addresses from environment variables

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -362,6 +362,7 @@ export const getRelationshipData = createEffect(
         input: S.string,
         output: relationshipSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -381,6 +382,7 @@ export const getStructureData = createEffect(
         input: S.string,
         output: structureSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -447,6 +449,7 @@ export const getAddressData = createEffect(
         input: S.string,
         output: addressSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -489,6 +492,7 @@ export const getPropertyData = createEffect(
         input: S.string,
         output: propertySchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -523,6 +527,7 @@ export const getIpfsFactSheetData = createEffect(
         input: S.string,
         output: ipfsFactSheetSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -543,7 +548,8 @@ export const getIpfsMetadata = createEffect(
         name: "getIpfsMetadata",
         input: S.string,
         output: ipfsMetadataSchema,
-        cache: true, // Enable caching for better performance
+        cache: true, // Enable caching for better performance,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchIpfsMetadataWithInfiniteRetry(context, cid);
@@ -556,6 +562,7 @@ export const getLotData = createEffect(
         input: S.string,
         output: lotDataSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -589,6 +596,7 @@ export const getSalesHistoryData = createEffect(
         input: S.string,
         output: salesHistorySchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -612,6 +620,7 @@ export const getTaxData = createEffect(
         input: S.string,
         output: taxSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -644,6 +653,7 @@ export const getUtilityData = createEffect(
         input: S.string,
         output: utilitySchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -683,6 +693,7 @@ export const getFloodStormData = createEffect(
         input: S.string,
         output: floodStormInformationSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -711,6 +722,7 @@ export const getPersonData = createEffect(
         input: S.string,
         output: personSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -739,6 +751,7 @@ export const getCompanyData = createEffect(
         input: S.string,
         output: companySchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -767,6 +780,7 @@ export const getCommunicationData = createEffect(
         input: S.string,
         output: communicationSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -788,6 +802,7 @@ export const getLayoutData = createEffect(
         input: S.string,
         output: layoutSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -840,6 +855,7 @@ export const getFileData = createEffect(
         input: S.string,
         output: fileSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -865,6 +881,7 @@ export const getDeedData = createEffect(
         input: S.string,
         output: deedSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(
@@ -886,6 +903,7 @@ export const getPropertyImprovementData = createEffect(
         input: S.string,
         output: propertyImprovementSchema,
         cache: true,
+        rateLimit: false,
     },
     async ({ input: cid, context }) => {
         return fetchDataWithInfiniteRetry(

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,4 +1,4 @@
-import { experimental_createEffect, S, type EffectContext } from "envio";
+import { createEffect, S, type EffectContext } from "envio";
 import {
     ipfsMetadataSchema,
     relationshipSchema,
@@ -356,7 +356,7 @@ async function fetchDataWithLimitedRetry<T>(
 }
 
 // Fetch relationship data (from/to structure)
-export const getRelationshipData = experimental_createEffect(
+export const getRelationshipData = createEffect(
     {
         name: "getRelationshipData",
         input: S.string,
@@ -375,7 +375,7 @@ export const getRelationshipData = experimental_createEffect(
 );
 
 // Fetch structure data (roof_date)
-export const getStructureData = experimental_createEffect(
+export const getStructureData = createEffect(
     {
         name: "getStructureData",
         input: S.string,
@@ -441,7 +441,7 @@ export const getStructureData = experimental_createEffect(
 );
 
 // Fetch address data
-export const getAddressData = experimental_createEffect(
+export const getAddressData = createEffect(
     {
         name: "getAddressData",
         input: S.string,
@@ -483,7 +483,7 @@ export const getAddressData = experimental_createEffect(
 );
 
 // Fetch property data (property_type, built years)
-export const getPropertyData = experimental_createEffect(
+export const getPropertyData = createEffect(
     {
         name: "getPropertyData",
         input: S.string,
@@ -516,9 +516,8 @@ export const getPropertyData = experimental_createEffect(
     }
 );
 
-
 // Fetch fact sheet data (ipfs_url and full_generation_command)
-export const getIpfsFactSheetData = experimental_createEffect(
+export const getIpfsFactSheetData = createEffect(
     {
         name: "getIpfsFactSheetData",
         input: S.string,
@@ -539,7 +538,7 @@ export const getIpfsFactSheetData = experimental_createEffect(
     }
 );
 
-export const getIpfsMetadata = experimental_createEffect(
+export const getIpfsMetadata = createEffect(
     {
         name: "getIpfsMetadata",
         input: S.string,
@@ -551,8 +550,7 @@ export const getIpfsMetadata = experimental_createEffect(
     }
 );
 
-
-export const getLotData = experimental_createEffect(
+export const getLotData = createEffect(
     {
         name: "getLotData",
         input: S.string,
@@ -585,7 +583,7 @@ export const getLotData = experimental_createEffect(
     }
 );
 
-export const getSalesHistoryData = experimental_createEffect(
+export const getSalesHistoryData = createEffect(
     {
         name: "getSalesHistoryData",
         input: S.string,
@@ -608,7 +606,7 @@ export const getSalesHistoryData = experimental_createEffect(
     }
 );
 
-export const getTaxData = experimental_createEffect(
+export const getTaxData = createEffect(
     {
         name: "getTaxData",
         input: S.string,
@@ -640,7 +638,7 @@ export const getTaxData = experimental_createEffect(
     }
 );
 
-export const getUtilityData = experimental_createEffect(
+export const getUtilityData = createEffect(
     {
         name: "getUtilityData",
         input: S.string,
@@ -679,7 +677,7 @@ export const getUtilityData = experimental_createEffect(
     }
 );
 
-export const getFloodStormData = experimental_createEffect(
+export const getFloodStormData = createEffect(
     {
         name: "getFloodStormData",
         input: S.string,
@@ -707,7 +705,7 @@ export const getFloodStormData = experimental_createEffect(
     }
 );
 
-export const getPersonData = experimental_createEffect(
+export const getPersonData = createEffect(
     {
         name: "getPersonData",
         input: S.string,
@@ -735,7 +733,7 @@ export const getPersonData = experimental_createEffect(
     }
 );
 
-export const getCompanyData = experimental_createEffect(
+export const getCompanyData = createEffect(
     {
         name: "getCompanyData",
         input: S.string,
@@ -763,7 +761,7 @@ export const getCompanyData = experimental_createEffect(
 );
 
 // Fetch communication data
-export const getCommunicationData = experimental_createEffect(
+export const getCommunicationData = createEffect(
     {
         name: "getCommunicationData",
         input: S.string,
@@ -784,7 +782,7 @@ export const getCommunicationData = experimental_createEffect(
     }
 );
 
-export const getLayoutData = experimental_createEffect(
+export const getLayoutData = createEffect(
     {
         name: "getLayoutData",
         input: S.string,
@@ -836,7 +834,7 @@ export const getLayoutData = experimental_createEffect(
     }
 );
 
-export const getFileData = experimental_createEffect(
+export const getFileData = createEffect(
     {
         name: "getFileData",
         input: S.string,
@@ -861,7 +859,7 @@ export const getFileData = experimental_createEffect(
     }
 );
 
-export const getDeedData = experimental_createEffect(
+export const getDeedData = createEffect(
     {
         name: "getDeedData",
         input: S.string,
@@ -882,7 +880,7 @@ export const getDeedData = experimental_createEffect(
 );
 
 // Fetch property improvement data
-export const getPropertyImprovementData = experimental_createEffect(
+export const getPropertyImprovementData = createEffect(
     {
         name: "getPropertyImprovementData",
         input: S.string,

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { TestHelpers, ERC1967Proxy_DataSubmitted } from "generated";
+import { TestHelpers, ERC1967Proxy_DataSubmitted } from "envio";
 const { MockDb, ERC1967Proxy } = TestHelpers;
 
 describe("ERC1967Proxy contract DataSubmitted event tests", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,22 @@
 {
   "compilerOptions": {
-    "target": "es2020", //required for use with BigInt types
-    "lib": [
-      "es2020"
-    ],
-    "allowJs": true,
-    "checkJs": false,
-    "outDir": "build",
-    "strict": true,
-    "noImplicitAny": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "skipLibCheck": true,
-    "module": "CommonJS"
-  },
-  "include": [
-    "src",
-    "test"
-  ]
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "strict": false,
+    "noImplicitOverride": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "lib": [
+      "es2022"
+    ],
+    "types": [
+      "node"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Upgrade `envio` (HyperIndex) to **3.2.1**
- Migrate config/handlers to the V3 API where needed (`networks` -> `chains`, `indexer.onEvent`, imports from `envio`, etc.)
- Refresh bundled agent skills via `envio skills update` (under `.claude/skills/`)

## Context
This indexer is deployed on Envio's hosted service. Merging this PR makes it straightforward to redeploy on 3.2.1.

## Test plan
- [ ] `pnpm install`
- [ ] `pnpm envio codegen`
- [ ] `pnpm dev` (or hosted redeploy) and confirm indexing starts
